### PR TITLE
XSS修正・UX改善・不要ライブラリ削除

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -94,9 +94,9 @@ main {
     margin-bottom: 0.5rem;
 }
 
-.file-types {
+.drop-zone-content .file-types {
     font-size: 0.8rem;
-    color: #86868b !important;
+    color: #86868b;
 }
 
 .drop-zone input[type="file"] {
@@ -439,6 +439,12 @@ button[type="submit"]:disabled {
 @media (max-width: 600px) {
     main {
         margin: 1rem auto;
+    }
+
+    .upload-section,
+    .job-section,
+    .jobs-section {
+        padding: 1rem;
     }
 
     .tabs {

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Session Digest{% endblock %}</title>
     <link rel="stylesheet" href="/static/style.css">
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
 </head>
 <body>
     <header>

--- a/templates/job.html
+++ b/templates/job.html
@@ -35,7 +35,7 @@
         <div class="tab-content {% if loop.first %}active{% endif %}" id="tab-{{ key }}" role="tabpanel">
             <div class="tab-actions">
                 <a href="/api/jobs/{{ job.id }}/download/{{ key }}" class="btn btn-download" id="download-{{ key }}">ダウンロード</a>
-                <button class="btn btn-regen" onclick="regenerate('{{ key }}')">再生成</button>
+                <button class="btn btn-regen" data-doc-type="{{ key }}">再生成</button>
             </div>
             <div class="doc-preview" id="preview-{{ key }}">
                 <p class="loading">読み込み中...</p>
@@ -46,7 +46,7 @@
 </div>
 
 <script>
-const jobId = "{{ job.id }}";
+const jobId = {{ job.id|tojson }};
 
 // Tab switching
 document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -65,8 +65,18 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 // SSE connection
 const evtSource = new EventSource(`/api/jobs/${jobId}/events`);
 
+// Regenerate buttons
+document.querySelectorAll('.btn-regen').forEach(btn => {
+    btn.addEventListener('click', () => regenerate(btn.dataset.docType));
+});
+
 evtSource.onmessage = function(event) {
-    const data = JSON.parse(event.data);
+    let data;
+    try {
+        data = JSON.parse(event.data);
+    } catch (e) {
+        return;
+    }
 
     if (data.type === 'progress') {
         const bar = document.getElementById('progress-bar');
@@ -168,12 +178,22 @@ function loadDocumentPreview(docType) {
 }
 
 function regenerate(docType) {
+    const btn = document.querySelector(`[data-doc-type="${docType}"]`);
+    if (btn) btn.disabled = true;
     fetch(`/api/jobs/${jobId}/regenerate/${docType}`, { method: 'POST' })
-        .then(r => r.json())
+        .then(r => {
+            if (!r.ok) throw new Error('Request failed');
+            return r.json();
+        })
         .then(() => {
             const el = document.getElementById('preview-' + docType);
             el.innerHTML = '<p class="loading">再生成中...</p>';
-        });
+        })
+        .catch(() => {
+            const el = document.getElementById('preview-' + docType);
+            el.innerHTML = '<p class="error-text">再生成リクエストに失敗しました。</p>';
+        })
+        .finally(() => { if (btn) btn.disabled = false; });
 }
 
 function escapeHtml(text) {
@@ -190,7 +210,7 @@ loadResults();
 {% elif job.status.value == 'failed' %}
 document.getElementById('progress-section').style.display = 'none';
 document.getElementById('error-section').style.display = 'block';
-document.getElementById('error-message').textContent = "{{ job.error or 'Unknown error' }}";
+document.getElementById('error-message').textContent = {{ (job.error or 'Unknown error')|tojson }};
 {% endif %}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- XSS修正: `tojson`フィルタでJS文字列埋め込みを安全化（job.id, job.error）
- inline `onclick` を `addEventListener` に統一（CSP対応）
- `JSON.parse` エラーハンドリング追加
- `regenerate()` にエラーハンドリング・二重送信防止を追加
- 未使用htmxライブラリを削除
- CSS `!important` 除去、モバイルpadding調整

## Test plan
- [ ] ジョブ詳細ページが正常表示されること
- [ ] 再生成ボタンの二重クリックが防止されること
- [ ] エラー時にメッセージが正しく表示されること

Closes #5