### PR TITLE
Docker Hardened Images (DHI) Alpine ベースに移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: docker build -t session-digest .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract version from tag
         id: meta
         uses: docker/metadata-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
-FROM python:3.12-slim
-
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
-
+FROM dhi.io/python:3.12-alpine3.21-dev AS builder
 WORKDIR /app
-
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+FROM dhi.io/python:3.12-alpine3.21-dev
+RUN apk add --no-cache ffmpeg
+WORKDIR /app
+COPY --from=builder /opt/python/lib/python3.12/site-packages /opt/python/lib/python3.12/site-packages
+COPY --from=builder /opt/python/bin /opt/python/bin
 COPY . .
-
-RUN useradd --create-home --shell /bin/bash appuser && \
+RUN adduser -D -s /bin/sh appuser && \
     mkdir -p /tmp/session-digest && \
     chown -R appuser:appuser /app /tmp/session-digest
-
 USER appuser
-
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/')" || exit 1
-
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-009688.svg)](https://fastapi.tiangolo.com)
 [![Docker](https://img.shields.io/badge/docker-ready-2496ED.svg)](https://www.docker.com/)
+[![Docker Hub](https://img.shields.io/docker/v/seijin4ka/session-digest?label=Docker%20Hub&sort=semver)](https://hub.docker.com/r/seijin4ka/session-digest)
 [![Issues](https://img.shields.io/github/issues/seijin4ka/session-digest)](https://github.com/seijin4ka/session-digest/issues)
 
 長時間セミナーの録音ファイルをアップロードするだけで、AIが自動的に以下の3種類のドキュメントを生成するWebアプリです。


### PR DESCRIPTION
## Summary
- `Dockerfile`: `python:3.12-slim` → `dhi.io/python:3.12-alpine3.21-dev` マルチステージビルド化
- CI/CD ワークフロー: `dhi.io` レジストリへのログインステップ追加
- `README.md`: Docker Hub バッジ追加

## Test plan
- [x] `docker compose up --build` でビルド・起動成功
- [x] ヘルスチェック (`http://localhost:8000/`) HTTP 200
- [x] `ffmpeg` / `ffprobe` 正常動作確認
- [ ] CI `docker-build` ジョブが通ること

Closes #9