### PR TITLE
fix: Docker コンテナ起動時の /tmp/session-digest 権限エラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,17 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 FROM dhi.io/python:3.12-alpine3.21-dev
-RUN apk upgrade --no-cache && apk add --no-cache ffmpeg
+RUN apk upgrade --no-cache && apk add --no-cache ffmpeg su-exec
 WORKDIR /app
 COPY --from=builder /opt/python/lib/python3.12/site-packages /opt/python/lib/python3.12/site-packages
 COPY --from=builder /opt/python/bin /opt/python/bin
 COPY . .
 RUN adduser -D -s /bin/sh appuser && \
     mkdir -p /tmp/session-digest && \
-    chown -R appuser:appuser /app /tmp/session-digest
-USER appuser
+    chown -R appuser:appuser /app
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/')" || exit 1
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+chown -R appuser:appuser /tmp/session-digest
+exec su-exec appuser "$@"


### PR DESCRIPTION
## 概要
named volume () がコンテナ起動時にマウントされる際、root オーナーの空ディレクトリで上書きされるため、 が書き込めずエラーが発生していました。

## 修正内容
- **entrypoint.sh**: コンテナ起動時に root で `/tmp/session-digest` の権限を `appuser` に修正してから、プロセスを `appuser` で起動
- **Dockerfile**: 
  - `su-exec` をインストール
  - `entrypoint.sh` をコピーして実行権限を付与
  - `USER appuser` を削除（entrypoint で権限切り替え）
  - `ENTRYPOINT` を `/entrypoint.sh` に設定

## 検証方法
```bash
docker compose down -v
docker compose up --build
# → ファイルアップロードが成功することを確認
# → docker compose exec app whoami → "appuser" と表示されること
```

Closes #15